### PR TITLE
ci/scripts: fix typo, update checkout action, fix path in attest help text

### DIFF
--- a/.github/workflows/latest_asmap.yml
+++ b/.github/workflows/latest_asmap.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - name: Find lastest ASMap file by timestamp
+    - name: Find latest ASMap file by timestamp
       id: find_latest
       run: |
         set -euo pipefail

--- a/asmap-attest
+++ b/asmap-attest
@@ -51,8 +51,8 @@ Example:
       ./asmap-attest
 
     Outputs:
-      \$PWD/2026/attestations/1772726379/satoshi/SHA256SUMS          (attestation)
-      \$PWD/2026/attestations/1772726379/satoshi/SHA256SUMS.asc      (signature)
+      \$PWD/attestations/2026/1772726379/satoshi/SHA256SUMS          (attestation)
+      \$PWD/attestations/2026/1772726379/satoshi/SHA256SUMS.asc      (signature)
 
 Environment variables:
 


### PR DESCRIPTION
Three small maintenance fixes:

- `.github/workflows/latest_asmap.yml`: fix "lastest" → "latest" typo in step name
- `.github/workflows/latest_asmap.yml`: update `actions/checkout` from v3 to v4 (v3 is deprecated)
- `asmap-attest`: fix transposed path in usage example — script writes to
  `attestations/<year>/<epoch>/` but example showed `<year>/attestations/<epoch>/`

Fixes #56 .