### PR TITLE
ci/scripts: extend CI trigger paths, fix diff portability, auto-import builder keys

### DIFF
--- a/.github/workflows/latest_asmap.yml
+++ b/.github/workflows/latest_asmap.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - '**/*.dat'
+      - 'attestations/**'
+      - 'builder-keys/**'
 
 jobs:
   validate:

--- a/asmap-verify
+++ b/asmap-verify
@@ -112,6 +112,11 @@ verify() {
     local signer_name
     signer_name="$(basename "$(dirname "$current_manifest")")"
 
+    local key_file="${builder_keys_dir}/${signer_name}.gpg"
+    if [ -f "$key_file" ]; then
+        gpg --quiet --batch --import "$key_file" 2>/dev/null || true
+    fi
+
     if ! gpg --quiet --batch \
             --verify "${current_manifest}.asc" "$current_manifest" 1>&2; then
         echo "ERR: Failed to verify GPG signature for signer '${signer_name}'"
@@ -123,7 +128,7 @@ verify() {
         echo "          gpg --import '${builder_keys_dir}/${signer_name}.gpg'"
         echo ""
         failure=1
-    elif ! diff --report-identical "$compare_base" "$current_manifest" 1>&2; then
+    elif ! diff -s "$compare_base" "$current_manifest" 1>&2; then
         echo "ERR: The SHA256SUMS attestation differs from the compare base:"
         echo "    base:    '${compare_base}'"
         echo "    current: '${current_manifest}'"


### PR DESCRIPTION
Three improvements to the CI workflow and `asmap-verify` script:

- **CI**: trigger the workflow on `attestations/**` and `builder-keys/**` changes
  in addition to `*.dat` files — attestation-only PRs currently skip validation entirely
- **asmap-verify**: replace non-standard `diff --report-identical` with portable
  `diff -s`, which works on both GNU and BSD (macOS) diff
- **asmap-verify**: auto-import the signer's builder key before GPG verification
  so the script works out of the box without a manual `gpg --import` step first

These are small improvements, hope they're welcome, would love to contribute more!

Fixes #56 .