### PR TITLE
Minor fixes from pull 57

### DIFF
--- a/.github/workflows/latest_asmap.yml
+++ b/.github/workflows/latest_asmap.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - name: Find lastest ASMap file by timestamp
+    - name: Find latest ASMap file by timestamp
       id: find_latest
       run: |
         set -euo pipefail

--- a/asmap-attest
+++ b/asmap-attest
@@ -51,8 +51,8 @@ Example:
       ./asmap-attest
 
     Outputs:
-      \$PWD/2026/attestations/1772726379/satoshi/SHA256SUMS          (attestation)
-      \$PWD/2026/attestations/1772726379/satoshi/SHA256SUMS.asc      (signature)
+      \$PWD/attestations/2026/1772726379/satoshi/SHA256SUMS          (attestation)
+      \$PWD/attestations/2026/1772726379/satoshi/SHA256SUMS.asc      (signature)
 
 Environment variables:
 


### PR DESCRIPTION
Some minor fixes from #57 which the author closed a few days after opening it. I couldn't just re-open the original pull because even the repo that the pull was based on was deleted.

- Fix "lastest" typo in CI workflow step name
- Update actions/checkout from v3 to v4 (v3 is deprecated)
- Fix transposed path in asmap-attest usage example: script writes to attestations/<year>/<epoch>/ but example showed <year>/attestations/<epoch>/

Received an ACK from @hodlinator here already, so with my review I am merging it now: https://github.com/bitcoin-core/asmap-data/pull/57#pullrequestreview-4505570099