### PR TITLE
Aggregate collaborative launch result hashes in the issue

### DIFF
--- a/.github/workflows/hash-aggregator.yml
+++ b/.github/workflows/hash-aggregator.yml
@@ -1,0 +1,124 @@
+name: Aggregate Collaborative Hashes
+
+on:
+  issue_comment:
+    types: [created, edited, deleted]
+  issues:
+    types: [opened, edited]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to refresh
+        required: true
+        type: string
+
+concurrency:
+  group: hash-agg-${{ github.event.issue.number || github.event.inputs.issue_number }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.issue.title, 'Collaborative Launch')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const MAGIC = '<!-- hash-aggregator-id: ae7c2bfe203c2f16d6574aae0e59e71d -->';
+            const SKIP = '<!--meta-tag:bot-skip-->';
+            const BOT = 'github-actions[bot]';
+            const { owner, repo } = context.repo;
+
+            // DrahtBot-style: ignore the bot's own comments (avoids edit loops)
+            if (context.eventName === 'issue_comment' &&
+                context.payload.comment.user.login === BOT) {
+              return;
+            }
+
+            function extractHash(line) {
+              if (line.trimStart().startsWith('>')) return null;
+              // Strip backticks/bold/italic wrappers; keyword is case-insensitive
+              const s = line.replace(/[`*_]+/g, '').trim();
+              const m = s.match(/^hash:\s*([0-9a-fA-F]{64})\s*$/i);
+              return m ? m[1].toLowerCase() : null;
+            }
+
+            function userLink(login) {
+              return `[${login}](https://github.com/${login})`;
+            }
+
+            let issue_number, title, state;
+            if (context.eventName === 'workflow_dispatch') {
+              issue_number = Number(context.payload.inputs.issue_number);
+              const issue = (await github.rest.issues.get({ owner, repo, issue_number })).data;
+              title = issue.title;
+              state = issue.state;
+            } else {
+              issue_number = context.issue.number;
+              title = context.payload.issue.title;
+              state = context.payload.issue.state;
+            }
+            if (!title.startsWith('Collaborative Launch')) return;
+            if (state !== 'open') return;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+
+            // Per user: set of distinct hashes across all their comments
+            const userHashes = new Map();
+            for (const c of comments) {
+              const body = c.body || '';
+              if (body.includes(MAGIC) || body.includes(SKIP)) continue;
+              const login = c.user.login;
+              if (!userHashes.has(login)) userHashes.set(login, new Set());
+              for (const line of body.split('\n')) {
+                const hash = extractHash(line);
+                if (hash) userHashes.get(login).add(hash);
+              }
+            }
+
+            const byHash = new Map();
+            for (const [user, hashes] of userHashes) {
+              for (const hash of hashes) {
+                if (!byHash.has(hash)) byHash.set(hash, []);
+                byHash.get(hash).push(user);
+              }
+            }
+            const rows = [...byHash.entries()]
+              .map(([hash, users]) => ({ hash, users: users.sort() }))
+              .sort((a, b) => b.users.length - a.users.length || a.hash.localeCompare(b.hash));
+
+            const n = [...userHashes.values()].filter(s => s.size > 0).length;
+            let table = '| hash | users | share of matches |\n| --- | --- | --- |\n';
+            if (!rows.length) {
+              table += '| _none_ | | |\n';
+            } else {
+              for (const r of rows) {
+                table += `| \`${r.hash}\` | ${r.users.map(userLink).join(', ')} | ${r.users.length}/${n} |\n`;
+              }
+            }
+            const body = [
+              MAGIC,
+              '### Collaborative Launch Hashes',
+              '',
+              table,
+              '',
+              'Report with one line `HASH: <sha256>` per result.',
+              'If a comment should be ignored by this table, copy-paste <code>&lt;!--meta-tag:bot-skip--&gt;</code> into it.',
+              '',
+            ].join('\n');
+
+            // Only treat the summary as magic. Skip API write if unchanged.
+            const magic = comments.find(c =>
+              c.user.login === BOT && (c.body || '').includes(MAGIC));
+            if (magic) {
+              if (magic.body === body) return;
+              await github.rest.issues.updateComment({ owner, repo, comment_id: magic.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }


### PR DESCRIPTION
This PR adds a GitHub Action that keeps one summary comment on open collaborative launch issues, with a table of matching result hashes (the part people used to tally by hand). Discussed in [#49](https://github.com/bitcoin-core/asmap-data/issues/49) and [maflcko's sketch in DrahtBot#80](https://github.com/maflcko/DrahtBot/issues/80#issuecomment-4244186245).

### What

On issues titled `Collaborative Launch …`, the action creates a summary comment when the issue opens and edits that same comment when the table changes.

Participants report results with lines like:

```
HASH: <sha256 of final_result.txt>
```


Every distinct hash a user posts counts once for them, whether the lines sit in one comment or spread across several ([voting rule](https://github.com/bitcoin-core/asmap-data/pull/64#issuecomment-5158293947)). Reposting the same hash adds no votes. This covers results from multiple machines.
The summary table is sorted by match count:

| hash | users | share of matches |
| --- | --- | --- |
| `xyz…` | [fjahr](https://github.com/fjahr), [jorisstrakeljahn](https://github.com/jorisstrakeljahn) | 2/3 |
| `abc…` | [jorisstrakeljahn](https://github.com/jorisstrakeljahn) | 1/3 |
| `def…` | third-user | 1/3 |

The denominator is the number of users who reported at least one hash. Comment edits and deletions trigger a rescan. Closed issues are ignored.

### Accepted `HASH:` lines

| Example | OK? |
| --- | --- |
| `HASH: <sha256>` | yes |
| `HASH:<sha256>` (no space) | yes |
| `Hash: <sha256>` / `hash: <sha256>` | yes |
| ``HASH: `<sha256>` `` | yes |
| `HASH: **<sha256>**` | yes |
| leading/trailing spaces on the line | yes |
| several such lines in one comment (distinct hashes) | yes, one vote per distinct hash |
| same hash repeated by the same user | counts once |

### Not accepted

| Example | OK? |
| --- | --- |
| wrong length / non-hex | no |
| `HASH:` with no hash | no |
| hash only in prose/logs, no `HASH:` prefix (e.g. `The SHA-256 hash of the result file is: …`) | no |
| `> HASH: <sha256>` (quoted line) | no |
| comment containing `<!--meta-tag:bot-skip-->` | whole comment ignored |

Suggested addition for launch issue bodies (for example [#63](https://github.com/bitcoin-core/asmap-data/issues/63)):

```
### Reporting your result

Post the SHA-256 of your `final_result.txt` on its own line:

HASH: <sha256 of final_result.txt>

If you ran on multiple machines, report each result. Every distinct hash you post counts once for you. A bot keeps a summary table in a comment below.
```

### Demo (fork)
- [#3](https://github.com/jorisstrakeljahn/asmap-data/issues/3): full test round on the current version
- Earlier rounds against the previous version: [#1](https://github.com/jorisstrakeljahn/asmap-data/issues/1), [#2](https://github.com/jorisstrakeljahn/asmap-data/issues/2)


### After merge

[#63](https://github.com/bitcoin-core/asmap-data/issues/63) is already open for the 6 August launch. Merge alone will not post the summary there (the issue was not newly opened). If this lands before the launch, someone with write access can trigger a one-time refresh (Actions: Aggregate Collaborative Hashes, issue number `63`, or a small issue edit). Otherwise the first comment on #63 after the merge creates the summary (empty table until `HASH:` lines arrive); later comments update it.

Happy to take suggestions on the summary comment or any other stuff.