### PR TITLE
Rename bot column to share of users

### DIFF
--- a/.github/workflows/hash-aggregator.yml
+++ b/.github/workflows/hash-aggregator.yml
@@ -94,7 +94,7 @@ jobs:
               .sort((a, b) => b.users.length - a.users.length || a.hash.localeCompare(b.hash));
 
             const n = [...userHashes.values()].filter(s => s.size > 0).length;
-            let table = '| hash | users | share of matches |\n| --- | --- | --- |\n';
+            let table = '| hash | users | share of users |\n| --- | --- | --- |\n';
             if (!rows.length) {
               table += '| _none_ | | |\n';
             } else {


### PR DESCRIPTION
As discussed in #63, this renames the third column of the bot table from "share of matches" to "share of users".